### PR TITLE
Refactor: Remove hardcoded API key and use Streamlit secrets

### DIFF
--- a/chat/.streamlit/secrets.toml
+++ b/chat/.streamlit/secrets.toml
@@ -1,1 +1,1 @@
-
+# Add your Groq API key here, e.g., apiGroq = "your_groq_api_key"

--- a/chatgpt/app.py
+++ b/chatgpt/app.py
@@ -4,7 +4,7 @@ from openai import OpenAI
 from docx import Document
 from io import BytesIO, StringIO
 
-apiGroq = "YOU_KEY"
+apiGroq = st.secrets.get("apiGroq")
 # Configuración de claves API (NO RECOMENDADO almacenar claves en código en producción)
 client = OpenAI(base_url="https://api.groq.com/openai/v1", api_key=apiGroq)
 


### PR DESCRIPTION
I removed a hardcoded Groq API key from `chatgpt/app.py` and replaced it with `st.secrets.get("apiGroq")`.

I also added a comment to `chat/.streamlit/secrets.toml` to guide you on adding your Groq API key.

I recommend you manually test the Streamlit application `chatgpt/app.py` to ensure it correctly retrieves the API key from Streamlit secrets.